### PR TITLE
Use spawn instead of execspawn to correctly handle quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var PATH_SEP = process.platform === 'win32' ? ';' : ':'
 var PATH_KEY = process.platform === 'win32' && !(process.env.PATH && !process.env.Path) ? 'Path' : 'PATH'
 
 var toString = function(cmd) {
-  return cmd.pattern || cmd.op || cmd
+  return cmd.pattern || cmd.op || '"' + cmd + '"'
 }
 
 var npmRunPath = function(cwd, PATH) {


### PR DESCRIPTION
Hey,

this fixed https://github.com/datproject/gasket/issues/6 for me, where this module removed quotes from the command (`jsonmap "delete this.arr"` to  `jsonmap delete this.arr`).

I think it is just possible to use spawn instead of execspawn.

Best,
Finn
